### PR TITLE
allow NuGet.exe, needed for package restore

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -146,6 +146,8 @@ publish/
 !**/packages/build/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
+# Allow NuGet.exe
+!NuGet.exe
 
 # Windows Azure Build Output
 csx/


### PR DESCRIPTION
NuGet.exe should get included in the changeset, as it is needed for restoring NuGet packages.